### PR TITLE
fix DefaultStopTime field description

### DIFF
--- a/cform/ec2-scheduler.template
+++ b/cform/ec2-scheduler.template
@@ -20,7 +20,7 @@
             "Default": "0800"
         },
         "DefaultStopTime": {
-            "Description": "Default Start Time (UTC, 24-hour format)",
+            "Description": "Default Stop Time (UTC, 24-hour format)",
             "Type": "String",
             "Default": "1800"
         },


### PR DESCRIPTION
fix `DefaultStopTime` field description that was probably copy/pasted from `DefaultStartTime` field description